### PR TITLE
Add command to get current version of Enabler

### DIFF
--- a/enabler/commands/cmd_version.py
+++ b/enabler/commands/cmd_version.py
@@ -1,0 +1,13 @@
+from enabler.cli import pass_environment, logger
+import pkg_resources
+import click
+
+# Command to get the current Enabler version 
+@click.group('version', short_help='Get current version of Enabler', invoke_without_command=True)
+@click.pass_context
+@pass_environment
+def cli(ctx, kube_context):   
+    """Get current version of Enabler"""
+    distribution = pkg_resources.get_distribution("enabler")
+    version = distribution.version
+    logger.info("Enabler "+version)


### PR DESCRIPTION
This PR is related to https://github.com/keitaroinc/devops-enabler/issues/36. 

This command can be tested by executing enabler version in Terminal.