### PR TITLE
Add option to assign --kube-context in subcommand

### DIFF
--- a/enabler/cli.py
+++ b/enabler/cli.py
@@ -45,11 +45,11 @@ class EnablerCLI(click.MultiCommand):
 @click.command(cls=EnablerCLI, context_settings=CONTEXT_SETTINGS)
 @click.option('--kube-context',
               help='The kubernetes context to use',
-              default='keitaro')
+              required=False)
 @click_log.simple_verbosity_option(logger)
 @pass_environment
 def cli(ctx, kube_context):
     """Enabler CLI for ease of setup of microservice based apps"""
-    ctx.kube_context = kube_context
 
-    logger.debug('Using kube-context: kind-' + kube_context)
+    ctx.kube_context = kube_context
+    logger.debug('Using kube-context: kind-' + str(kube_context))

--- a/enabler/commands/cmd_apps.py
+++ b/enabler/commands/cmd_apps.py
@@ -7,7 +7,7 @@ import subprocess as s
 @click.group('apps', short_help='App commands')
 @click.pass_context
 @pass_environment
-def cli(ctx, kube_context):
+def cli(ctx, kube_context_cli):
     """Application specific commands such as creation of kubernetes
     objects such as namespaces, configmaps etc. The name of the
     context is taken from the option --kube-context
@@ -17,13 +17,18 @@ def cli(ctx, kube_context):
 
 # Namespace setup
 @cli.command('namespace', short_help='Create namespace')
+@click.option('--kube-context',
+              help='The kubernetes context to use',
+              required=False)
 @click.argument('name',
                 required=True)
 @click.pass_context
 @pass_environment
-def ns(ctx, kube_context, name):
+def ns(ctx, kube_context_cli, kube_context, name):
     """Create a namespace with auto-injection"""
-    kube_context = ctx.kube_context
+
+    if ctx.kube_context is not None:
+        kube_context = ctx.kube_context
 
     # Create a namespace in kubernetes
     ns_exists = s.run(['kubectl',

--- a/enabler/commands/cmd_apps.py
+++ b/enabler/commands/cmd_apps.py
@@ -29,6 +29,9 @@ def ns(ctx, kube_context_cli, kube_context, name):
 
     if ctx.kube_context is not None:
         kube_context = ctx.kube_context
+    if ctx.kube_context is None and kube_context is None:
+        logger.error("--kube-context was not specified")
+        raise click.Abort()
 
     # Create a namespace in kubernetes
     ns_exists = s.run(['kubectl',

--- a/enabler/commands/cmd_kind.py
+++ b/enabler/commands/cmd_kind.py
@@ -13,7 +13,7 @@ import socket
 @click.group('kind', short_help='Manage kind clusters')
 @click.pass_context
 @pass_environment
-def cli(ctx, kube_context1):
+def cli(ctx, kube_context_cli):
     """Manage kind clusters.
     The name of the cluster is taken from the option --kube-context
     which defaults to 'keitaro'"""
@@ -29,7 +29,7 @@ def cli(ctx, kube_context1):
               required=False)
 @click.pass_context
 @pass_environment
-def create(ctx, kube_context1, kube_context, configfile):
+def create(ctx, kube_context_cli, kube_context, configfile):
     """Create a kind cluster"""
   
     if kube_context is None:
@@ -70,7 +70,7 @@ def create(ctx, kube_context1, kube_context, configfile):
               required=False)
 @click.pass_context
 @pass_environment
-def delete(ctx, kube_context1, kube_context):
+def delete(ctx, kube_context_cli, kube_context):
     """Delete a kind cluster"""
     # Check if the kind cluster exists
     if ctx.kube_context is not None:
@@ -119,7 +119,7 @@ def status(ctx, kube_context):
               required=False)
 @click.pass_context
 @pass_environment
-def start(ctx,kube_context1, kube_context):
+def start(ctx,kube_context_cli, kube_context):
     """Start kind cluster"""
 
     # Kind creates containers with a label io.x-k8s.kind.cluster
@@ -190,7 +190,7 @@ def start(ctx,kube_context1, kube_context):
               required=False)
 @click.pass_context
 @pass_environment
-def stop(ctx,kube_context1, kube_context):
+def stop(ctx,kube_context_cli, kube_context):
     """Stop kind cluster"""
     # Check if the cluster exists
     if ctx.kube_context is not None:

--- a/enabler/commands/cmd_kind.py
+++ b/enabler/commands/cmd_kind.py
@@ -16,7 +16,7 @@ import socket
 def cli(ctx, kube_context_cli):
     """Manage kind clusters.
     The name of the cluster is taken from the option --kube-context
-    which defaults to 'keitaro'"""
+    """
     pass
 
 
@@ -32,9 +32,11 @@ def cli(ctx, kube_context_cli):
 def create(ctx, kube_context_cli, kube_context, configfile):
     """Create a kind cluster"""
   
-    if kube_context is None:
+    if ctx.kube_context is not None:
         kube_context=ctx.kube_context
-
+    if ctx.kube_context is None and kube_context is None:
+        logger.error("--kube-context was not specified")
+        raise click.Abort()
 
     #Check if config file exists 
     base_name, extension = os.path.splitext(configfile)
@@ -75,6 +77,10 @@ def delete(ctx, kube_context_cli, kube_context):
     # Check if the kind cluster exists
     if ctx.kube_context is not None:
         kube_context = ctx.kube_context
+    if ctx.kube_context is None and kube_context is None:
+        logger.error("--kube-context was not specified")
+        raise click.Abort()
+    
     if not kind.kind_get(kube_context):
         logger.error('Kind cluster \'' + kube_context + '\' doesn\'t exist')
         raise click.Abort()
@@ -129,6 +135,9 @@ def start(ctx,kube_context_cli, kube_context):
 
     if ctx.kube_context is not None:
         kube_context = ctx.kube_context
+    if ctx.kube_context is None and kube_context is None:
+        logger.error("--kube-context was not specified")
+        raise click.Abort()
 
     
     kind_cp = kube_context + '-control-plane'
@@ -195,6 +204,9 @@ def stop(ctx,kube_context_cli, kube_context):
     # Check if the cluster exists
     if ctx.kube_context is not None:
         kube_context = ctx.kube_context
+    if ctx.kube_context is None and kube_context is None:
+        logger.error("--kube-context was not specified")
+        raise click.Abort()
 
     # Kind creates containers with a label io.x-k8s.kind.cluster
     # Kind naming is clustername-control-plane and clustername-worker{x}

--- a/enabler/commands/cmd_kind.py
+++ b/enabler/commands/cmd_kind.py
@@ -13,7 +13,7 @@ import socket
 @click.group('kind', short_help='Manage kind clusters')
 @click.pass_context
 @pass_environment
-def cli(ctx, kube_context):
+def cli(ctx, kube_context1):
     """Manage kind clusters.
     The name of the cluster is taken from the option --kube-context
     which defaults to 'keitaro'"""
@@ -24,13 +24,18 @@ def cli(ctx, kube_context):
 @click.argument('configfile',
                 type=click.Path(exists=True),
                 default='kind-cluster.yaml')
+@click.option('--kube-context',
+              help='The kubernetes context to use',
+              required=False)
 @click.pass_context
 @pass_environment
-def create(ctx, kube_context, configfile):
+def create(ctx, kube_context1, kube_context, configfile):
     """Create a kind cluster"""
-    
-    kube_context = ctx.kube_context
-    
+  
+    if kube_context is None:
+        kube_context=ctx.kube_context
+
+
     #Check if config file exists 
     base_name, extension = os.path.splitext(configfile)
     if not os.path.exists(configfile) or extension!='.yaml':
@@ -38,13 +43,11 @@ def create(ctx, kube_context, configfile):
         raise click.Abort()
     
     kind_configfile_validation(configfile)
-
-    # Check if kind cluster is already created    
+        
+    #Check if kind cluster is already created
     if kind.kind_get(kube_context):
         logger.error('Kind cluster \'' + kube_context + '\' already exists')
         raise click.Abort()
-
-    # Create the kind cluster
     try:
         logger.debug('Running: `kind create cluster`')
         create_cluster = s.run(['kind',
@@ -60,13 +63,18 @@ def create(ctx, kube_context, configfile):
                         str(error))
 
 
+
 @cli.command('delete', short_help='Delete cluster')
+@click.option('--kube-context',
+              help='The kubernetes context to use',
+              required=False)
 @click.pass_context
 @pass_environment
-def delete(ctx, kube_context):
+def delete(ctx, kube_context1, kube_context):
     """Delete a kind cluster"""
     # Check if the kind cluster exists
-    kube_context = ctx.kube_context
+    if ctx.kube_context is not None:
+        kube_context = ctx.kube_context
     if not kind.kind_get(kube_context):
         logger.error('Kind cluster \'' + kube_context + '\' doesn\'t exist')
         raise click.Abort()
@@ -85,12 +93,16 @@ def delete(ctx, kube_context):
 
 
 @cli.command('status', short_help='Cluster status')
+@click.option('--kube-context',
+              help='The kubernetes context to use',
+              required=False)
 @click.pass_context
 @pass_environment
 def status(ctx, kube_context):
     """Check the status of the kind cluster"""
     # Check if the cluster exists
-    kube_context = ctx.kube_context
+    if ctx.kube_context is not None:
+        kube_context = ctx.kube_context
     if kind.kind_get(kube_context):
         if kube.kubectl_info(kube_context):
             logger.info('Kind cluster \'' + kube_context + '\' is running')
@@ -102,20 +114,27 @@ def status(ctx, kube_context):
 
 
 @cli.command('start', short_help='Start cluster')
+@click.option('--kube-context',
+              help='The kubernetes context to use',
+              required=False)
 @click.pass_context
 @pass_environment
-def start(ctx, kube_context):
+def start(ctx,kube_context1, kube_context):
     """Start kind cluster"""
-    # Check if the cluster exists
-    kube_context = ctx.kube_context
 
     # Kind creates containers with a label io.x-k8s.kind.cluster
     # Kind naming is clustername-control-plane and clustername-worker{x}
     # The idea is to find the containers check status and ports
     # and start them then configure kubectl context
+
+    if ctx.kube_context is not None:
+        kube_context = ctx.kube_context
+
+    
     kind_cp = kube_context + '-control-plane'
     kind_workers = kube_context + '-worker'
 
+    # Check if the cluster exists
     if kind.kind_get(kube_context):
         if kube.kubectl_info(kube_context):
             logger.info('Kind cluster \'' + kube_context + '\' is running')
@@ -166,12 +185,16 @@ def start(ctx, kube_context):
 
 
 @cli.command('stop', short_help='Stop cluster')
+@click.option('--kube-context',
+              help='The kubernetes context to use',
+              required=False)
 @click.pass_context
 @pass_environment
-def stop(ctx, kube_context):
+def stop(ctx,kube_context1, kube_context):
     """Stop kind cluster"""
     # Check if the cluster exists
-    kube_context = ctx.kube_context
+    if ctx.kube_context is not None:
+        kube_context = ctx.kube_context
 
     # Kind creates containers with a label io.x-k8s.kind.cluster
     # Kind naming is clustername-control-plane and clustername-worker{x}
@@ -198,9 +221,12 @@ def stop(ctx, kube_context):
         logger.error('Kind cluster \'' + kube_context + '\' does not exist.')
 
 
+
 #Functions to check if config file has neccessary fields and localhost port is free
 def kind_configfile_validation(configfile):
     """Validates kind-cluster.yaml file"""
+
+    #Get content of configfile
     with open(configfile, 'r') as yaml_file:
         yaml_content = yaml_file.read()
 
@@ -244,3 +270,10 @@ def check_if_port_is_free(port_number):
         return False
 
     return True
+
+
+
+
+
+
+   

--- a/enabler/commands/cmd_platform.py
+++ b/enabler/commands/cmd_platform.py
@@ -15,7 +15,7 @@ import subprocess as s
 @click.group('platform', short_help='Platform commands')
 @click.pass_context
 @pass_environment
-def cli(ctx, kube_context):
+def cli(ctx, kube_context_cli):
     """Platform commands to help with handling the codebase and repo"""
     pass
 
@@ -30,7 +30,7 @@ def cli(ctx, kube_context):
                 default=os.getcwd())
 @click.pass_context
 @pass_environment
-def init(ctx, kube_context, submodules, repopath):
+def init(ctx,  kube_context_cli, submodules, repopath):
     """Init the platform by doing submodule init and checkout
     all submodules on master"""
 
@@ -46,18 +46,21 @@ def init(ctx, kube_context, submodules, repopath):
                 smodule.update()
                 logger.info('Fetching latest changes for {}'.format(submodule))
             except Exception as e:
-                logger.error('An error occurred while updating {submodule}: {e}'.format(submodule,e))
+                logger.error(f'An error occurred while updating {submodule}: {e}'.format(submodule,e))
 
     logger.info('Platform initialized.')
 
 
 @cli.command('info', short_help='Get info on platform')
+@click.option('--kube-context',
+              help='The kubernetes context to use',
+              required=False)
 @click.pass_context
 @pass_environment
-def info(ctx, kube_context):
+def info(ctx,  kube_context_cli, kube_context):
     """Get info on platform and platform components"""
-    kube_context = ctx.kube_context
-
+    if ctx.kube_context is not None:
+        kube_context = ctx.kube_context
     try:
         gw_url = s.run(['kubectl',
                         '--context',
@@ -86,7 +89,7 @@ def info(ctx, kube_context):
                 default=2048)
 @click.pass_context
 @pass_environment
-def keys(ctx, kube_context, bits):
+def keys(ctx,  kube_context_cli, bits):
     """Generate encryption keys used by the application services"""
     # Locations, we can argument these if need be
     keys_dir = 'infrastructure/keys/'
@@ -142,7 +145,7 @@ def keys(ctx, kube_context, bits):
                 default=os.getcwd())
 @click.pass_context
 @pass_environment
-def release(ctx, kube_context, version, submodules, repopath):
+def release(ctx,  kube_context_cli, version, submodules, repopath):
     """Release platform by tagging platform repo and
     tagging all individual components (git submodules)
     using their respective SHA that the submodules point at"""
@@ -164,7 +167,7 @@ def release(ctx, kube_context, version, submodules, repopath):
                 default=os.getcwd())
 @click.pass_context
 @pass_environment
-def version(ctx, kube_context, submodules, repopath):
+def version(ctx, kube_context_cli, submodules, repopath):
     """Check versions of microservices in git submodules
         You can provide a comma separated list of submodules
         or you can use 'all' for all submodules"""

--- a/enabler/commands/cmd_platform.py
+++ b/enabler/commands/cmd_platform.py
@@ -10,6 +10,8 @@ import click_spinner
 import git
 import os
 import subprocess as s
+import pkg_resources
+
 
 # App group of commands
 @click.group('platform', short_help='Platform commands')
@@ -61,6 +63,9 @@ def info(ctx,  kube_context_cli, kube_context):
     """Get info on platform and platform components"""
     if ctx.kube_context is not None:
         kube_context = ctx.kube_context
+    if ctx.kube_context is None and kube_context is None:
+        logger.error("--kube-context was not specified")
+        raise click.Abort()
     try:
         gw_url = s.run(['kubectl',
                         '--context',

--- a/enabler/commands/cmd_preflight.py
+++ b/enabler/commands/cmd_preflight.py
@@ -7,7 +7,7 @@ import subprocess as s
 @click.command('preflight', short_help='Preflight checks')
 @click.pass_context
 @pass_environment
-def cli(ctx, kube_context):
+def cli(ctx, kube_context_cli):
     """Preflight checks to ensure all tools and versions are present"""
     # Check java
     try:

--- a/enabler/commands/cmd_setup.py
+++ b/enabler/commands/cmd_setup.py
@@ -100,6 +100,9 @@ def metallb(ctx, kube_context_cli, kube_context):
     # Check if metallb is installed
     if ctx.kube_context is not None:
         kube_context = ctx.kube_context
+    if ctx.kube_context is None and kube_context is None:
+        logger.error("--kube-context was not specified")
+        raise click.Abort()
 
     try:
         metallb_exists = s.run(['helm',
@@ -221,6 +224,9 @@ def istio(ctx, kube_context_cli,kube_context, monitoring_tools):
     """Install and setup istio on k8s"""
     if ctx.kube_context is not None:
         kube_context = ctx.kube_context
+    if ctx.kube_context is None and kube_context is None:
+        logger.error("--kube-context was not specified")
+        raise click.Abort()
 
     # Run verify install to check whether we are ready to install istio
     try:

--- a/enabler/commands/cmd_setup.py
+++ b/enabler/commands/cmd_setup.py
@@ -14,7 +14,7 @@ import tarfile
 @click.group('setup', short_help='Setup infrastructure services')
 @click.pass_context
 @pass_environment
-def cli(ctx, kube_context):
+def cli(ctx, kube_context_cli):
     """Setup infrastructure services on kubernetes.
     The name of the context is taken from the option --kube-context
     which defaults to 'keitaro'"""
@@ -25,7 +25,7 @@ def cli(ctx, kube_context):
 @cli.command('init', short_help='Initialize dependencies')
 @click.pass_context
 @pass_environment
-def init(ctx, kube_context):
+def init(ctx, kube_context_cli):
     """Download binaries for all dependencies"""
 
     # Figure out what kind of OS are we on
@@ -90,12 +90,16 @@ def init(ctx, kube_context):
 
 # Metallb setup
 @cli.command('metallb', short_help='Setup metallb')
+@click.option('--kube-context',
+              help='The kubernetes context to use',
+              required=False)
 @click.pass_context
 @pass_environment
-def metallb(ctx, kube_context):
+def metallb(ctx, kube_context_cli, kube_context):
     """Install and setup metallb on k8s"""
     # Check if metallb is installed
-    kube_context = ctx.kube_context
+    if ctx.kube_context is not None:
+        kube_context = ctx.kube_context
 
     try:
         metallb_exists = s.run(['helm',
@@ -205,15 +209,18 @@ def metallb(ctx, kube_context):
 
 # Istio setup
 @cli.command('istio', short_help='Setup Istio')
+@click.option('--kube-context',
+              help='The kubernetes context to use',
+              required=False)
 @click.argument('monitoring_tools',
                 required=False
                 )
 @click.pass_context
 @pass_environment
-def istio(ctx, kube_context,monitoring_tools):
+def istio(ctx, kube_context_cli,kube_context, monitoring_tools):
     """Install and setup istio on k8s"""
-    kube_context = ctx.kube_context
-    kube_context='vmt'
+    if ctx.kube_context is not None:
+        kube_context = ctx.kube_context
 
     # Run verify install to check whether we are ready to install istio
     try:

--- a/enabler/commands/cmd_version.py
+++ b/enabler/commands/cmd_version.py
@@ -6,7 +6,7 @@ import click
 @click.group('version', short_help='Get current version of Enabler', invoke_without_command=True)
 @click.pass_context
 @pass_environment
-def cli(ctx, kube_context):   
+def cli(ctx, kube_context_cli):   
     """Get current version of Enabler"""
     distribution = pkg_resources.get_distribution("enabler")
     version = distribution.version


### PR DESCRIPTION
This PR is related to: https://github.com/keitaroinc/devops-enabler/issues/41

The idea is to have both possibilities for the --kube-context option to write an enabler command ie:
both enabler --kube-context keitaro setup istio and enabler setup istio --kube-context keitaro will work. So it can be applied for  previous projects.  