### PR TITLE
Istio config file as template

### DIFF
--- a/enabler/commands/cmd_setup.py
+++ b/enabler/commands/cmd_setup.py
@@ -268,6 +268,7 @@ def istio(ctx, kube_context_cli,kube_context, monitoring_tools):
             
         istio_command.append('--context')
         istio_command.append('kind-'+ kube_context)
+        istio_command.append('--wait')
         try:
             istio_install = s.run(istio_command,
                                   capture_output=True, check=True)
@@ -277,3 +278,12 @@ def istio(ctx, kube_context_cli,kube_context, monitoring_tools):
             logger.critical('Istio installation failed')
             logger.critical(error.stderr.decode('utf-8'))
             raise click.Abort()
+        if monitoring_tools=='monitoring-tools':
+            try:
+                grafana_virtual_service=s.run(['kubectl','apply','-f','enabler/grafana-vs.yaml'],
+                                  capture_output=True, check=True)
+            except Exception as e:
+                logger.error('Error setting grafana URL')
+                logger.error(str(e))
+            
+                

--- a/enabler/grafana-vs.yaml
+++ b/enabler/grafana-vs.yaml
@@ -1,0 +1,36 @@
+apiVersion:  networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: grafana-gateway
+  namespace: istio-system
+spec:
+  selector:
+    app: istio-ingressgateway
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    tls:
+      httpsRedirect: false
+    hosts:
+    - "grafana.local"
+    
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: grafana-vs
+  namespace: istio-system
+spec:
+  hosts:
+  - "grafana.local"
+  gateways:
+  - grafana-gateway
+  http:
+  - route:
+    - destination:
+        port:
+          number: 3000
+        host: grafana


### PR DESCRIPTION
This PR is related to: https://github.com/keitaroinc/devops-enabler/issues/25

With this we configure a virtual service and gateway to expose grafana outside of the cluster if the service is activated. The URL to open grafana is grafana.local. This address should be mapped out in etc/hosts as:
 istio-ingressgateway_EXTERNAL_IP  grafana.local