### PR TITLE
Metallb image is depreciated

### DIFF
--- a/enabler/commands/cmd_setup.py
+++ b/enabler/commands/cmd_setup.py
@@ -199,8 +199,6 @@ def metallb(ctx, kube_context_cli, kube_context):
         helm_metallb = s.run(['helm',
                               'install',
                               'metallb',
-                               '-f',
-                               'enabler/metallb-crd.yaml',
                                '--kube-context',
                               'kind-' + kube_context,
                               '--version',

--- a/enabler/commands/cmd_setup.py
+++ b/enabler/commands/cmd_setup.py
@@ -189,18 +189,25 @@ def metallb(ctx, kube_context_cli, kube_context):
     # Install metallb on the cluster
     try:
         helm_metallb = s.run(['helm',
-                        'install',
-                        '--kube-context',
-                        'kind-' + kube_context,
-                        'metallb',
-                    #   '--set',
-                    #   metallb_config,
-                        '-n',
-                        'metallb',
-                        '--version',
-                        '4.6.0',
-                        'bitnami/metallb'],
-                        capture_output=True, check=True)
+                              'install',
+                              'metallb',
+                               '-f',
+                               'enabler/metallb-crd.yaml',
+                               '--kube-context',
+                              'kind-' + kube_context,
+                              '--version',
+                              '4.6.0',
+                              'bitnami/metallb' ,                            
+                              '-n',
+                              'metallb',
+                              '--wait'],
+                             capture_output=True, check=True)
+
+        config_metallb=s.run(['kubectl',
+                                'apply',
+                                '-f',
+                                'enabler/metallb-crd.yaml'],
+                                capture_output=True, check=True)
 
         logger.info('✓ Metallb installed on cluster.')
         logger.debug(helm_metallb.stdout.decode("utf-8"))

--- a/enabler/commands/cmd_setup.py
+++ b/enabler/commands/cmd_setup.py
@@ -9,6 +9,7 @@ import urllib.request
 import os
 import stat
 import tarfile
+import yaml
 
 # Setup group of commands
 @click.group('setup', short_help='Setup infrastructure services')
@@ -154,12 +155,19 @@ def metallb(ctx, kube_context_cli, kube_context):
     logger.info('Metallb will be configured in Layer 2 mode with the range: ' +
                 metallb_ips[0] + ' - ' + metallb_ips[-1])
 
-    # Metallb layer2 configuration
-    metallb_config = (
-                   'configInline.address-pools[0].name=default,'
-                   'configInline.address-pools[0].protocol=layer2,'
-                   'configInline.address-pools[0].addresses[0]='
-                    + metallb_ips[0] + '-' + metallb_ips[-1])
+    # Dynamically set the IP Address range in the CRD .yaml file
+    yaml_file_path='enabler/metallb-crd.yaml'
+    with open(yaml_file_path, 'r') as yaml_file:
+        config = list(yaml.safe_load_all(yaml_file))
+
+    ip_string= metallb_ips[0] + ' - ' + metallb_ips[-1]
+
+    for doc in config:
+        if 'kind' in doc and doc['kind'] == 'IPAddressPool':
+            doc['spec']['addresses'] = [ip_string]
+
+    with open(yaml_file_path, 'w') as yaml_file:
+        yaml.dump_all(config, yaml_file, default_flow_style=False)
 
     # Create a namespace for metallb if it doesn't exist
     ns_exists = s.run(['kubectl',
@@ -202,7 +210,7 @@ def metallb(ctx, kube_context_cli, kube_context):
                               'metallb',
                               '--wait'],
                              capture_output=True, check=True)
-
+        # Apply configuration from CRD file  
         config_metallb=s.run(['kubectl',
                                 'apply',
                                 '-f',

--- a/enabler/commands/cmd_setup.py
+++ b/enabler/commands/cmd_setup.py
@@ -189,18 +189,18 @@ def metallb(ctx, kube_context_cli, kube_context):
     # Install metallb on the cluster
     try:
         helm_metallb = s.run(['helm',
-                              'install',
-                              '--kube-context',
-                              'kind-' + kube_context,
-                              'metallb',
-                              '--set',
-                              metallb_config,
-                              '-n',
-                              'metallb',
-                              '--version',
-                              '3.0.12',
-                              'bitnami/metallb'],
-                             capture_output=True, check=True)
+                        'install',
+                        '--kube-context',
+                        'kind-' + kube_context,
+                        'metallb',
+                    #   '--set',
+                    #   metallb_config,
+                        '-n',
+                        'metallb',
+                        '--version',
+                        '4.6.0',
+                        'bitnami/metallb'],
+                        capture_output=True, check=True)
 
         logger.info('✓ Metallb installed on cluster.')
         logger.debug(helm_metallb.stdout.decode("utf-8"))

--- a/metallb-crd.yaml
+++ b/metallb-crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: vmt-ip-pool
+  namespace: metallb
+spec:
+  addresses:
+    - 172.18.255.246-172.18.255.255
+
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: protocol
+  namespace: metallb 
+spec:
+  ipAddressPools:
+  - vmt-ip-pool
+

--- a/metallb-crd.yaml
+++ b/metallb-crd.yaml
@@ -1,7 +1,7 @@
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
-  name: vmt-ip-pool
+  name: ip-pool
   namespace: metallb
 spec:
   addresses:
@@ -15,5 +15,5 @@ metadata:
   namespace: metallb 
 spec:
   ipAddressPools:
-  - vmt-ip-pool
+  - ip-pool
 


### PR DESCRIPTION
This PR is related to: https://github.com/keitaroinc/devops-enabler/issues/26

Newer versions of Metallb are configured using a CDR (Custom Resource Definition) .yaml file, which should be applied to the metallb settings. 