### PR TITLE
Add arguments for version and IP address range in metallb setup command

### DIFF
--- a/enabler/commands/cmd_setup.py
+++ b/enabler/commands/cmd_setup.py
@@ -169,7 +169,7 @@ def metallb(ctx, kube_context_cli, kube_context, ip_addresspool,version):
             start_ip=ipaddress.IPv4Address(ip_range[0])
             end_ip=ipaddress.IPv4Address(ip_range[1])
         except:
-            logger.error('Incorect IP address range: '+ ip_addresspool)
+            logger.error('Incorrect IP address range: '+ ip_addresspool)
 
         if start_ip not in ipaddress.IPv4Network(kind_subnet) or end_ip not in ipaddress.IPv4Network(kind_subnet):
             logger.error('Provided IP address range not in kind network. Kind subnet is: ' + kind_subnet)

--- a/enabler/commands/cmd_setup.py
+++ b/enabler/commands/cmd_setup.py
@@ -171,7 +171,7 @@ def metallb(ctx, kube_context_cli, kube_context, ip_addresspool,version):
             config = yaml.safe_load(yaml_file)
         
         
-        modified_string = config['data']['config'][:-32]+ip_addresspool
+        modified_string = config['data']['config'][:-32]+ip_addresspool+"\n"
         
         config['data']['config'] = modified_string 
 

--- a/metallb-configmap.yaml
+++ b/metallb-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb
+  name: metallb-config
+data:
+  config: |
+    address-pools:
+    - name: ip-pool
+      protocol: layer2
+      addresses:
+      - 172.18.255.246 - 172.18.255.250


### PR DESCRIPTION
This PR is related to: https://github.com/keitaroinc/devops-enabler/issues/47

When calling the command enabler setup metallb, there should be an option for the version of metallb and the ip address range given to metallb to be assigned dynamically as an argument in the cli command. The default values for version should be 4.6.0 and for metallb IP address range - the last 10 IP addresses of the kind network subnet.
If the version of Metallb is >=4.0.0 then a CRD file should be used, else the installation is configured by a config map. 