### PR TITLE
Prepare 0.1.3 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enabler_keitaro_inc"
-version = "0.1.2"
+version = "0.1.3"
 description = "Enabler is a CLI application built for making life easier when working on microservice-based applications. Through this package we can create, edit and execute custom commands to configure microservices."
 authors = ["Keitaro Inc. <info@keitaro.com>"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="enabler",
-    version="0.1.2",
+    version="0.1.3",
     packages=["enabler", "src.enabler_keitaro_inc.commands", "src.enabler_keitaro_inc.helpers"], # noqa
     include_package_data=True,
     install_requires=["click>=7.1",

--- a/src/enabler_keitaro_inc/commands/cmd_version.py
+++ b/src/enabler_keitaro_inc/commands/cmd_version.py
@@ -8,6 +8,6 @@ import click
 @pass_environment
 def cli(ctx, kube_context_cli):
     """Get current version of Enabler"""
-    distribution = pkg_resources.get_distribution("enabler")
+    distribution = pkg_resources.get_distribution("enabler_keitaro_inc")
     version = distribution.version
     logger.info("Enabler "+version)

--- a/tests/version_unittests.py
+++ b/tests/version_unittests.py
@@ -9,7 +9,7 @@ class TestVersionCommands(unittest.TestCase):
 
     @patch('src.enabler_keitaro_inc.enabler.subprocess.run')
     def test_version_command(self, mock_subprocess_run):
-        mock_subprocess_run.return_value.stdout = 'Enabler 0.1.2'
+        mock_subprocess_run.return_value.stdout = 'Enabler 0.1.3'
         version = self.cli.version_command()
-        expected_version = 'Enabler 0.1.2'
+        expected_version = 'Enabler 0.1.3'
         self.assertEqual(version, expected_version)


### PR DESCRIPTION
In this PR, the enabler release has been upgraded to 0.1.3, and the issue with the command enabler version has been resolved.